### PR TITLE
Fix app not starting on Ubuntu

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // 'use strict';
-const {app, BrowserWindow,Menu,Tray} = require('electron')
-const path = require('path')
-const url = require('url')
+const {app, BrowserWindow,Menu,Tray} = require('electron');
+const path = require('path');
+const url = require('url');
 // require('electron-reload')(__dirname);
 
 // Keep a global reference of the window object, if you don't, the window will
@@ -19,19 +19,21 @@ function createWindow () {
         webSecurity: false,
     });
     win.maximize();
+
     // and load the index.html of the app.
+    win.loadURL(url.format({
+        pathname: path.join(__dirname, 'index.html'),
+        protocol: 'file:',
+        slashes: true
+    }));
+
+    // optional - open dev tools
     // win.webContents.openDevTools();
-    win.loadURL(__dirname+'/index.html');
 
     win.once('ready-to-show', function() {
         win.show();
         win.focus();
-
     });
-
-
-
-
 }
 
 // This method will be called when Electron has finished
@@ -44,26 +46,21 @@ app.on('window-all-closed', () => {
     // On macOS it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q
     if (process.platform !== 'darwin') {
-    app.quit()
-}
+        app.quit();
+    }
 });
 
 app.on('activate', () => {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     if (win === null) {
-    createWindow()
-}
+        createWindow();
+    }
 });
-
-
 
 global.clearCache = function(){
     const ses = win.webContents.session;
     ses.clearStorageData(function () {
        console.log('done');
     });
-
 }
-
-


### PR DESCRIPTION
When running the app via `npm start` on Ubuntu (16.04 LTS), the app simply loads a blank page (no errors). The changes made to `index.js` in this PR fixes the issue. 

Please note that this has not been tested in Windows, but the code comes from the official [electron](https://electron.atom.io/docs/tutorial/quick-start/) docs.